### PR TITLE
Move setTimeout Promise

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -60,10 +60,11 @@ if (import.meta.main) {
         } catch (error) {
           console.error(error);
         }
+        
+        await new Promise((resolve) => {
+          setTimeout(resolve, 5000 + (Math.random() * 5000));
+        });
       }
-      await new Promise((resolve) => {
-        setTimeout(resolve, 5000 + (Math.random() * 5000));
-      });
     }
 
     await kv.set(videosKey, allVideos);


### PR DESCRIPTION
Move the setTimeout Promise to only be called when the transcript is gathered from YT. There is no need to delay during future runs of the tool, if the captions are already downloaded.